### PR TITLE
fixed holiday API module to return hol instead of print hol in 

### DIFF
--- a/app.py
+++ b/app.py
@@ -57,7 +57,7 @@ def get_result():
 
     # get a list of holidays from holiday API
     # each holiday is a dictionary that contains name, description and date of holiday
-    holidays_list = holiday_api.get_holiday_data(country, year, month)
+    holidays_list = holiday_api.get_holiday(country, year, month)
 
     # get a dictionary of climate data for the specified month
     # contains temp high, temp low, rainfall in inches, sunshine hours

--- a/holiday_cal/holiday_api.py
+++ b/holiday_cal/holiday_api.py
@@ -59,8 +59,8 @@ def lis_of_countries(countries):
         results.append(name_code)
     return results    
         
-           
- #holiday endpoint
+
+#holiday endpoint
 @lru_cache(maxsize=1)          
 def get_holiday_data(country,year,month):
     """ call holiday api with the provided data.
@@ -69,7 +69,7 @@ def get_holiday_data(country,year,month):
     query = {'country': country, 'year': year, 'month': month, 'type':'national','api_key':api_key}
     req = req_holiday(query)
     return req
- 
+
 
 def req_holiday(query):
     """ make a api request with the provided data. """
@@ -77,7 +77,7 @@ def req_holiday(query):
     req = requests.get(url_holiday,params=query).json()
     res = req['response']['holidays']
     return None if res == [] else res 
-  
+
 
 def display_holiday(holiday):
     """ displays all holidays with the provided data.
@@ -90,6 +90,7 @@ def extract_country_holiday(holiday_data):
     """ extract holiday data.
     :param: holiday api response
     :returns: dictionary of the holiday data to render to the user.  """
+    holidays_list = []
     for hol in holiday_data:
         holiday_name = hol['name']
         description = hol['description']
@@ -99,7 +100,8 @@ def extract_country_holiday(holiday_data):
             'description':description,
             'date':holiday_date
         }
-    return holiday_dict
+        holidays_list.append(holiday_dict)
+    return holidays_list
 
 
 # method call for dropdown only 
@@ -107,6 +109,7 @@ def list_of_countries():
     country = req_res_country()
     return None if country == None else country
 
+# method call for holiday data in app.py
 def get_holiday(country_name,year,month):
     """ :params: the country_code(upperCase),year and month of travel.
     :returns holday name,description,date """
@@ -125,7 +128,7 @@ def country_code_handler(country_name):
     country_code = is_country_supported(country_name)
     return country_code
 
-             
+
 def get_travel_data(country,year,month):
     """ request holiday data from calendarificAPI.
     :params: country year and month are data the user provided.
@@ -138,7 +141,7 @@ def show_holiday(holiday):
     """ display the holiday data. """
     if holiday != None:
         hol = display_holiday(holiday)
-        print(hol)
+        return hol
     else:
         print('No data found')
         return None

--- a/holiday_cal/test_holiday_api.py
+++ b/holiday_cal/test_holiday_api.py
@@ -1,0 +1,48 @@
+import unittest
+from unittest import TestCase
+from unittest.case import expectedFailure
+from unittest.mock import patch
+
+import os
+
+import holiday_api
+
+api_key = os.environ.get('CALENDAR_KEY')
+
+class TestHolidayAPI(TestCase):
+
+    def test_is_country_supported(self):
+        country_name = 'Afghanistan'
+        returned_country_code = holiday_api.is_country_supported(country_name)
+        expected_country_code = 'AF'
+
+        self.assertEqual(expected_country_code, returned_country_code)
+
+
+    def test_get_holiday_data(self):
+        expected_holiday_data_response = [{'name': 'Christmas Day', 'description': 'Christmas Day is one of the biggest Christian celebrations and falls on December 25 in the Gregorian calendar.', 'country': {'id': 'se', 'name': 'Sweden'}, 'date': {'iso': '2022-12-25', 'datetime': {'year': 2022, 'month': 12, 'day': 25}}, 'type': ['National holiday'], 'locations': 'All', 'states': 'All'},
+        {'name': 'Boxing Day', 'description': 'Boxing Day is a public holiday in Sweden', 'country': {'id': 'se', 'name': 'Sweden'}, 'date': {'iso': '2022-12-26', 'datetime': {'year': 2022, 'month': 12, 'day': 26}}, 'type': ['National holiday'], 'locations': 'All', 'states': 'All'}]
+        returned_holiday_data_response = holiday_api.get_holiday_data('SE','2022','12')
+        
+        self.assertEqual(expected_holiday_data_response, returned_holiday_data_response)
+
+    
+    def test_req_holiday(self):
+        expected_holidays_response = [{'name': 'Christmas Day', 'description': 'Christmas Day is one of the biggest Christian celebrations and falls on December 25 in the Gregorian calendar.', 'country': {'id': 'se', 'name': 'Sweden'}, 'date': {'iso': '2022-12-25', 'datetime': {'year': 2022, 'month': 12, 'day': 25}}, 'type': ['National holiday'], 'locations': 'All', 'states': 'All'},
+        {'name': 'Boxing Day', 'description': 'Boxing Day is a public holiday in Sweden', 'country': {'id': 'se', 'name': 'Sweden'}, 'date': {'iso': '2022-12-26', 'datetime': {'year': 2022, 'month': 12, 'day': 26}}, 'type': ['National holiday'], 'locations': 'All', 'states': 'All'}]
+        sample_query = {'country': 'SE', 'year': '2022', 'month': '12', 'type':'national','api_key':api_key}
+        returned_holidays_response = holiday_api.req_holiday(sample_query)
+        
+        self.assertEqual(expected_holidays_response, returned_holidays_response)
+    
+
+    def test_get_holiday(self):
+        expected_holiday_list = [{'holiday_name': 'Christmas Day', 'description': 'Christmas Day is one of the biggest Christian celebrations and falls on December 25 in the Gregorian calendar.', 'date': '2022-12-25'},
+        {'holiday_name': 'Boxing Day', 'description': 'Boxing Day is a public holiday in Sweden', 'date': '2022-12-26'}]
+        returned_holiday_list = holiday_api.get_holiday('Sweden','2022','12')
+
+        self.assertEqual(expected_holiday_list, returned_holiday_list)
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/test_app.py
+++ b/test_app.py
@@ -170,7 +170,7 @@ class TestResultRoute(TestCase):
 
 
     @patch('weather.weather_api.get_coordinates', side_effect=[create_sample_coordinates()])
-    @patch('holiday_cal.holiday_api.get_holiday_data', side_effect=[create_sample_holiday_data()])
+    @patch('holiday_cal.holiday_api.get_holiday', side_effect=[create_sample_holiday_data()])
     @patch('weather.weather_api.get_climate', side_effect=[create_sample_weather_data()])
     @patch('windy_module.windy_api_manager.get_image_list', side_effect=[create_sample_webcam_data()])
     def test_get_valid_result(self, mock_get_coords, mock_get_holiday, mock_get_climate, mock_get_webcams):
@@ -205,7 +205,7 @@ class TestResultRoute(TestCase):
 
 
     @patch('weather.weather_api.get_coordinates', side_effect=[None])
-    @patch('holiday_cal.holiday_api.get_holiday_data', side_effect=[create_sample_holiday_data()])
+    @patch('holiday_cal.holiday_api.get_holiday', side_effect=[create_sample_holiday_data()])
     @patch('weather.weather_api.get_climate', side_effect=[create_sample_weather_data()])
     @patch('windy_module.windy_api_manager.get_image_list', side_effect=[create_sample_webcam_data()])
     def test_get_result_with_no_coordinates_shows_error_page(self, mock_get_coords, mock_get_holiday, mock_get_climate, mock_get_webcams):
@@ -219,7 +219,7 @@ class TestResultRoute(TestCase):
 
 
     @patch('weather.weather_api.get_coordinates', side_effect=[create_sample_coordinates()])
-    @patch('holiday_cal.holiday_api.get_holiday_data', side_effect=[None])
+    @patch('holiday_cal.holiday_api.get_holiday', side_effect=[None])
     @patch('weather.weather_api.get_climate', side_effect=[None])
     @patch('windy_module.windy_api_manager.get_image_list', side_effect=[None])
     def test_result_page_shows_correct_error_messages_when_no_optional_data_from_APIs(self, mock_get_coords, mock_get_holiday, mock_get_climate, mock_get_webcams):
@@ -236,7 +236,7 @@ class TestResultRoute(TestCase):
 
 
     @patch('weather.weather_api.get_coordinates', side_effect=[create_sample_coordinates()])
-    @patch('holiday_cal.holiday_api.get_holiday_data', side_effect=[None])
+    @patch('holiday_cal.holiday_api.get_holiday', side_effect=[None])
     @patch('weather.weather_api.get_climate', side_effect=[None])
     @patch('windy_module.windy_api_manager.get_image_list', side_effect=[None])
     def test_result_page_does_not_show_html_with_blank_entries_when_no_optional_data_from_APIs(self, mock_get_coords, mock_get_holiday, mock_get_climate, mock_get_webcams):
@@ -260,7 +260,7 @@ class TestResultRoute(TestCase):
 
 
     @patch('weather.weather_api.get_coordinates', side_effect=[create_sample_coordinates()])
-    @patch('holiday_cal.holiday_api.get_holiday_data', side_effect=[create_sample_holiday_data()])
+    @patch('holiday_cal.holiday_api.get_holiday', side_effect=[create_sample_holiday_data()])
     @patch('weather.weather_api.get_climate', side_effect=[None])
     @patch('windy_module.windy_api_manager.get_image_list', side_effect=[None])
     def test_result_page_shows_correct_error_messages_when_only_some_optional_data_from_APIs(self, mock_get_coords, mock_get_holiday, mock_get_climate, mock_get_webcams):
@@ -284,7 +284,7 @@ class TestResultRoute(TestCase):
 
 
     @patch('weather.weather_api.get_coordinates', side_effect=[create_sample_coordinates()])
-    @patch('holiday_cal.holiday_api.get_holiday_data', side_effect=[create_sample_multple_holiday_data()])
+    @patch('holiday_cal.holiday_api.get_holiday', side_effect=[create_sample_multple_holiday_data()])
     @patch('weather.weather_api.get_climate', side_effect=[None])
     @patch('windy_module.windy_api_manager.get_image_list', side_effect=[None])
     def test_result_page_shows_multiple_holidays(self, mock_get_coords, mock_get_holiday, mock_get_climate, mock_get_webcams):


### PR DESCRIPTION
addresses issue #22 

show_holiday was printing the holiday data instead of returning it, causing the next function to get None. I tested this in unit tests and when running the program and it seems to work now! I also put a comment next to the function I am supposed to use in app.py and changed to the correct function, I had initially been using holiday_api.get_holiday_data but realized I needed to use holiday_api.get_holiday instead